### PR TITLE
Add support for user-installed applications in ~/.local/share/applications

### DIFF
--- a/plugins/AppsPlugin/Plugin.vala
+++ b/plugins/AppsPlugin/Plugin.vala
@@ -70,6 +70,7 @@ public class Detective.AppsProvider : SearchProvider {
     public static MatchType match_type_apps;
 
     private string[] paths = {
+        Environment.get_home_dir () + "/.local/share",
         Environment.get_home_dir () + "/.local/share/flatpak/exports/share",
         "/var/lib/flatpak/exports/share",
         "/var/lib/snapd/desktop"


### PR DESCRIPTION
This commit adds the user's local applications directory to the search paths, allowing Detective to find and search applications installed directly by the user (e.g., AppImages, manually installed .desktop files, and other non-flatpak/snap apps).

<img width="707" height="164" alt="image" src="https://github.com/user-attachments/assets/afa2eb7a-a59f-4f88-b2d2-ac01c3b7560c" />
