### PR TITLE
fix: Remove result when user enters invalid expression.

### DIFF
--- a/plugins/CalculatorPlugin/Plugin.vala
+++ b/plugins/CalculatorPlugin/Plugin.vala
@@ -38,6 +38,8 @@ public class Detective.CalculatorProvider : SearchProvider {
     }
 
     private async void search_internal (Query query) {
+        matches_internal.remove_all ();
+
         try {
             string d = yield backend.get_solution (
                 query.search_term,
@@ -47,7 +49,6 @@ public class Detective.CalculatorProvider : SearchProvider {
             var icon = new ThemedIcon ("accessories-calculator");
             var match = new Match ( 0, d, null, icon, null);
 
-            matches_internal.remove_all ();
             matches_internal.append (match);
         } catch (Error e) {
             if (!(e is IOError.FAILED_HANDLED)) {


### PR DESCRIPTION
#### Problem
When the user typed a mathematical expression (e.g., "10+10"), the result ("20") was displayed correctly. However, when deleting and typing a new search that was not a valid expression (e.g., "elementary.io"), the previous result continued to be displayed, even though it was no longer relevant.

#### Root Cause

The problem was in the execution order in plugins/CalculatorPlugin/Plugin.vala:40-57:
The problematic flow was:

1. User types "10+10"
2. `backend.get_solution()` successfully returns "20"
3. `matches_internal.remove_all()` is executed (inside the `try` block)
4. Result "20" is added
5. User types "elementary.io"
6. `backend.get_solution()` throws an error (not a valid expression)
7. The code enters the `catch` block
8. `remove_all()` **is never called**, so "20" remains in the list

#### Solution
The fix was to move `matches_internal.remove_all()` to **before** the `try-catch` block:

#### Expected Behavior

**Before:**
1. Type "10+10" → shows "20"
2. Type "test" → continues showing "20" ❌

[before.webm](https://github.com/user-attachments/assets/801ca8c9-0523-4c62-b8d1-0cd14698640e)

**After:**
1. Type "10+10" → shows "20"
2. Type "test" → "20" disappears ✅

[after.webm](https://github.com/user-attachments/assets/32f14258-67ec-4b43-b015-108c1aeb2507)

