### PR TITLE
feat: Modernize for elementary OS 8.1 & Add Drill-down Navigation

### DIFF
--- a/lib/Results/Result.vala
+++ b/lib/Results/Result.vala
@@ -36,6 +36,10 @@ public class Detective.Result : Object {
         return null;
     }
 
+    public virtual GLib.ListModel? get_actions () {
+        return null;
+    }
+
     public virtual async void activate () throws Error {
         debug ("Activated result without activate func");
     }

--- a/plugins/AppsPlugin/Plugin.vala
+++ b/plugins/AppsPlugin/Plugin.vala
@@ -2,6 +2,7 @@ public class Detective.AppMatch : Result {
     public string app_id { get; construct; }
     public string exec { get; construct; }
     public string[] keywords { get; construct; }
+    public ListStore actions_store { get; private set; }
 
     private string[] title_tokens;
     private string[] description_tokens;
@@ -21,6 +22,11 @@ public class Detective.AppMatch : Result {
     construct {
         title_tokens = title.tokenize_and_fold (null, null);
         description_tokens = description?.tokenize_and_fold (null, null) ?? new string[0];
+        actions_store = new ListStore (typeof (AppActionMatch));
+    }
+
+    public override GLib.ListModel? get_actions () {
+        return actions_store;
     }
 
     public int set_relevancy (Query query) {
@@ -63,6 +69,32 @@ public class Detective.AppMatch : Result {
             app_info.launch (null, null);
         } else {
             Process.spawn_command_line_async ("flatpak-spawn --host " + exec);
+        }
+    }
+}
+
+public class Detective.CustomActionMatch : Result {
+    public string command { get; construct; }
+    public int action_type { get; construct; } // 0: exec, 1: clipboard, 2: pkexec
+
+    public CustomActionMatch (string title, string? description, Icon? icon, string command, int action_type) {
+        Object (
+            relevancy: 0,
+            title: title,
+            description: description,
+            icon: icon,
+            command: command,
+            action_type: action_type
+        );
+    }
+
+    public override async void activate () throws Error {
+        if (action_type == 1) { // Clipboard
+            Gdk.Display.get_default ().get_clipboard ().set_text (command);
+        } else if (action_type == 2) { // pkexec
+            Process.spawn_command_line_async ("pkexec " + command);
+        } else {
+            Process.spawn_command_line_async (command);
         }
     }
 }
@@ -180,10 +212,9 @@ public class Detective.AppsProvider : SearchProvider {
         // Make sure preferred entries come first here
         paths += Environment.get_user_data_dir ();
         foreach (var dir in Environment.get_system_data_dirs ()) {
+            paths += dir; // Fix to load native apps properly
             if (dir.has_prefix ("/usr")) {
                 paths += "/run/host" + dir; // /usr dirs aren't available from the sandbox
-            } else {
-                paths += dir;
             }
         }
 
@@ -370,7 +401,8 @@ public class Detective.AppsProvider : SearchProvider {
             debug ("Failed to get keywords: %s", e.message);
         }
 
-        list_store.append (new AppMatch (app_id, title, description, icon, exec, keywords));
+        var app_match = new AppMatch (app_id, title, description, icon, exec, keywords);
+        list_store.append (app_match);
         found_desktop_ids.add (app_id);
 
         try {
@@ -409,13 +441,20 @@ public class Detective.AppsProvider : SearchProvider {
                         continue;
                     }
 
-                    actions_list_store.append (
-                        new AppActionMatch (app_id, action_id, action_name, title, icon, action_exec)
-                    );
+                    var action_match = new AppActionMatch (app_id, action_id, action_name, title, icon, action_exec);
+                    actions_list_store.append (action_match);
+                    app_match.actions_store.append (action_match);
                 }
             }
         } catch (Error e) {
             debug ("Failed to parse actions for %s: %s", app_id, e.message);
+        }
+
+        // Acciones profesionales generadas por defecto para cada app (Nivel 2026)
+        if (exec != null && exec != "") {
+            app_match.actions_store.append (new CustomActionMatch (_("Ejecutar como Administrador"), _("Abre la aplicación con privilegios elevados"), new ThemedIcon ("security-high-symbolic"), exec, 2));
+            app_match.actions_store.append (new CustomActionMatch (_("Copiar comando"), _("Copia la ruta del ejecutable al portapapeles"), new ThemedIcon ("edit-copy-symbolic"), exec, 1));
+            app_match.actions_store.append (new CustomActionMatch (_("Ver Detalles"), _("Mostrar identificador de la app"), new ThemedIcon ("dialog-information-symbolic"), app_id, 1));
         }
     }
 

--- a/plugins/FilePlugin/Plugin.vala
+++ b/plugins/FilePlugin/Plugin.vala
@@ -1,3 +1,22 @@
+public class Detective.FileActionMatch : Result {
+    public delegate void ActionCallback ();
+    private ActionCallback callback;
+
+    public FileActionMatch (string title, string? description, Icon? icon, owned ActionCallback callback) {
+        Object (
+            relevancy: 0,
+            title: title,
+            description: description,
+            icon: icon
+        );
+        this.callback = (owned) callback;
+    }
+
+    public override async void activate () throws Error {
+        this.callback ();
+    }
+}
+
 public class Detective.FileMatch : Result {
     public string uri { get; construct; }
 
@@ -13,6 +32,58 @@ public class Detective.FileMatch : Result {
 
     public override async void activate () throws Error {
         yield new Gtk.FileLauncher (File.new_for_uri (uri)).launch (null, null);
+    }
+
+    public override GLib.ListModel? get_actions () {
+        var actions = new GLib.ListStore (typeof (Result));
+        
+        // Open Location
+        actions.append (new Detective.FileActionMatch (
+            _("Open Location"),
+            _("Open the folder containing this file"),
+            new ThemedIcon ("folder-symbolic"),
+            () => {
+                var file = File.new_for_uri (uri);
+                var parent = file.get_parent ();
+                if (parent != null) {
+                    new Gtk.FileLauncher (parent).launch.begin (null, null);
+                }
+            }
+        ));
+
+        // Copy Path
+        actions.append (new Detective.FileActionMatch (
+            _("Copy Path"),
+            _("Copy the absolute file path to clipboard"),
+            new ThemedIcon ("edit-copy-symbolic"),
+            () => {
+                var display = Gdk.Display.get_default ();
+                if (display != null) {
+                    string path = uri;
+                    try {
+                        path = Filename.from_uri (uri, null);
+                    } catch (Error e) {}
+                    display.get_clipboard ().set_text (path);
+                }
+            }
+        ));
+
+        // Move to Trash
+        actions.append (new Detective.FileActionMatch (
+            _("Move to Trash"),
+            _("Move this file to the trash bin"),
+            new ThemedIcon ("user-trash-symbolic"),
+            () => {
+                try {
+                    var file = File.new_for_uri (uri);
+                    file.trash (null);
+                } catch (Error e) {
+                    warning ("Failed to trash file: %s", e.message);
+                }
+            }
+        ));
+
+        return actions;
     }
 }
 

--- a/src/SearchWindow.vala
+++ b/src/SearchWindow.vala
@@ -53,14 +53,8 @@ public class Detective.SearchWindow : Gtk.ApplicationWindow {
             max_content_height = MAX_HEIGHT,
         };
 
-        var preview = new Preview (selection_model);
-
-        var paned = new Gtk.Paned (HORIZONTAL) {
-            start_child = scrolled_window,
-            end_child = preview,
-        };
         selection_model.bind_property (
-            "n-items", paned, "visible", SYNC_CREATE,
+            "n-items", scrolled_window, "visible", SYNC_CREATE,
             (binding, from_value, ref to_value) => {
                 to_value.set_boolean (from_value.get_uint () > 0);
                 return true;
@@ -68,21 +62,77 @@ public class Detective.SearchWindow : Gtk.ApplicationWindow {
         );
 
         var toolbar_view = new Adw.ToolbarView () {
-            content = paned
+            content = scrolled_window
         };
         toolbar_view.add_top_bar (entry);
+
+        var hint_box = new Gtk.Box (HORIZONTAL, 12) {
+            margin_start = 12,
+            margin_end = 12,
+            margin_top = 6,
+            margin_bottom = 6,
+            halign = Gtk.Align.END
+        };
+
+        var nav_box = new Gtk.Box (HORIZONTAL, 6);
+        var nav_key = new Gtk.Label ("Tab");
+        nav_key.add_css_class ("keycap");
+        var nav_desc = new Gtk.Label ("Navegar");
+        nav_desc.add_css_class ("dim-label");
+        nav_box.append (nav_key);
+        nav_box.append (nav_desc);
+
+        var enter_box = new Gtk.Box (HORIZONTAL, 6);
+        var enter_key = new Gtk.Label ("Enter");
+        enter_key.add_css_class ("keycap");
+        var enter_desc = new Gtk.Label ("Abrir");
+        enter_desc.add_css_class ("dim-label");
+        enter_box.append (enter_key);
+        enter_box.append (enter_desc);
+
+        var action_box = new Gtk.Box (HORIZONTAL, 6);
+        var action_key = new Gtk.Label ("→");
+        action_key.add_css_class ("keycap");
+        var action_desc = new Gtk.Label ("Acciones");
+        action_desc.add_css_class ("dim-label");
+        action_box.append (action_key);
+        action_box.append (action_desc);
+
+        hint_box.append (nav_box);
+        hint_box.append (enter_box);
+        hint_box.append (action_box);
+
+        selection_model.bind_property (
+            "n-items", hint_box, "visible", SYNC_CREATE,
+            (binding, from_value, ref to_value) => {
+                to_value.set_boolean (from_value.get_uint () > 0);
+                return true;
+            }
+        );
+
+        toolbar_view.add_bottom_bar (hint_box);
 
         resizable = false;
         child = toolbar_view;
         titlebar = new Gtk.Grid () { visible = false };
-        default_width = 700;
+        default_width = 650; // Un poco más estrecho al no tener panel de vista previa
         hide_on_close = true;
+
+        // ESTO SOLUCIONA EL BUG DE ENFOQUE AL BAJAR CON FLECHAS
+        entry.set_key_capture_widget (this);
 
         notify["is-active"].connect (on_is_active_changed);
         close_request.connect (on_close_request);
         map.connect (() => entry.grab_focus ());
 
         entry.search_changed.connect (() => {
+            if (in_actions_view) {
+                if (actions_filter != null) {
+                    actions_filter.changed (Gtk.FilterChange.DIFFERENT);
+                }
+                return;
+            }
+
             if (entry.text.strip () != "") {
                 engine.search (entry.text);
             } else {
@@ -96,6 +146,7 @@ public class Detective.SearchWindow : Gtk.ApplicationWindow {
         list_view.activate.connect (activate_result);
 
         var key_controller = new Gtk.EventControllerKey ();
+        key_controller.set_propagation_phase (Gtk.PropagationPhase.CAPTURE);
         key_controller.key_pressed.connect (on_key_pressed);
         child.add_controller (key_controller);
 
@@ -137,11 +188,62 @@ public class Detective.SearchWindow : Gtk.ApplicationWindow {
     }
 
     private void on_entry_activated () {
-        activate_result.begin (selection_model.selected);
+        var sel_model = (Gtk.SingleSelection) list_view.model;
+        if (sel_model.selected != Gtk.INVALID_LIST_POSITION) {
+            activate_result.begin (sel_model.selected);
+        }
+    }
+
+    private bool in_actions_view = false;
+    private string previous_search = "";
+    private Gtk.CustomFilter actions_filter = null;
+    private GLib.ListModel current_actions = null;
+
+    private void show_actions (Result result, GLib.ListModel actions) {
+        in_actions_view = true;
+        previous_search = entry.text;
+        current_actions = actions;
+        
+        for (uint i = 0; i < actions.get_n_items (); i++) {
+            var a = (Result) actions.get_item (i);
+            if (a != null) {
+                a.result_type_name = result.title;
+            }
+        }
+
+        actions_filter = new Gtk.CustomFilter ((obj) => {
+            if (entry.text.strip () == "") return true;
+            var r = (Result) obj;
+            return r.title.down ().contains (entry.text.down ().strip ()) ||
+                   (r.description != null && r.description.down ().contains (entry.text.down ().strip ()));
+        });
+
+        var filter_model = new Gtk.FilterListModel (actions, actions_filter);
+        var actions_selection = new Gtk.SingleSelection (filter_model) {
+            autoselect = true
+        };
+        list_view.model = actions_selection;
+
+        // Limpiar el texto para dejar buscar en el drill-down
+        entry.text = "";
+        entry.placeholder_text = result.title + " \u203A " + _("Buscar acciones...");
+    }
+
+    private void hide_actions () {
+        if (in_actions_view) {
+            in_actions_view = false;
+            list_view.model = selection_model;
+            entry.text = previous_search;
+            entry.placeholder_text = _("Search apps, files and more...");
+            current_actions = null;
+            var editable = (Gtk.Editable) entry;
+            editable.set_position (-1);
+        }
     }
 
     private async void activate_result (uint position) {
-        var result = (Result) engine.results.get_item (position);
+        var sel_model = (Gtk.SingleSelection) list_view.model;
+        var result = (Result) sel_model.get_item (position);
 
         if (result == null) {
             return;
@@ -157,8 +259,60 @@ public class Detective.SearchWindow : Gtk.ApplicationWindow {
 
     private bool on_key_pressed (uint keyval, uint keycode) {
         if (keyval == Gdk.Key.Escape) {
+            if (in_actions_view) {
+                hide_actions ();
+                return Gdk.EVENT_STOP;
+            }
             close ();
             return Gdk.EVENT_STOP;
+        } else if (keyval == Gdk.Key.Right) {
+            var editable = (Gtk.Editable) entry;
+            if (!in_actions_view && editable.get_position () < editable.get_text ().char_count ()) {
+                return Gdk.EVENT_PROPAGATE;
+            }
+
+            if (!in_actions_view && selection_model.selected != Gtk.INVALID_LIST_POSITION) {
+                var selected_item = engine.results.get_item (selection_model.selected);
+                if (selected_item != null && selected_item is Result) {
+                    var result = (Result) selected_item;
+                    var actions = result.get_actions ();
+                    if (actions != null && actions.get_n_items () > 0) {
+                        show_actions (result, actions);
+                        return Gdk.EVENT_STOP;
+                    }
+                }
+            }
+        } else if (keyval == Gdk.Key.Left) {
+            if (in_actions_view) {
+                hide_actions ();
+                return Gdk.EVENT_STOP;
+            }
+        } else if (keyval == Gdk.Key.Tab || keyval == Gdk.Key.Down) {
+            var sel_model = (Gtk.SingleSelection) list_view.model;
+            var n_items = sel_model.get_n_items ();
+            if (n_items > 0) {
+                var next = sel_model.selected + 1;
+                if (next >= n_items) next = 0;
+                sel_model.select_item (next, true);
+                list_view.scroll_to (next, Gtk.ListScrollFlags.SELECT, null);
+                return Gdk.EVENT_STOP;
+            }
+        } else if (keyval == Gdk.Key.Up) {
+            var sel_model = (Gtk.SingleSelection) list_view.model;
+            var n_items = sel_model.get_n_items ();
+            if (n_items > 0) {
+                var prev = sel_model.selected;
+                if (prev == 0) prev = n_items - 1;
+                else prev--;
+                sel_model.select_item (prev, true);
+                list_view.scroll_to (prev, Gtk.ListScrollFlags.SELECT, null);
+                return Gdk.EVENT_STOP;
+            }
+        } else if (keyval == Gdk.Key.BackSpace) {
+            if (in_actions_view && entry.text.length == 0) {
+                hide_actions ();
+                return Gdk.EVENT_STOP;
+            }
         }
 
         return Gdk.EVENT_PROPAGATE;


### PR DESCRIPTION
## Resumen de los cambios
* **Mejoras visuales para elementary OS 8.1**: Se ha implementado un diseño limpio usando las clases base y la tipografía nativa (`.dim-label`, `.keycap`) eliminando custom CSS intrusivo.
* **Navegación tipo Drill-down**: Se añadió soporte para explorar acciones secundarias de los resultados presionando la tecla Flecha Derecha (`->`), evitando conflictos con el foco de `Gtk.SearchEntry` en Wayland/GTK4.
* **Nuevas Acciones Profesionales (Apps/Files)**:
  * Aplicaciones: Se extraen las Desktop Actions nativas y se añadieron acciones universales (Ver Detalles, Copiar Comando, Ejecutar como Administrador).
  * Archivos: Se implementó un Drill-down propio para Abrir Ubicación, Copiar Ruta y Mover a la Papelera.
* **Hints de teclado nativos**: Se añadieron pistas usando las clases `.keycap` de elementary OS.